### PR TITLE
Add way to specify a custom Adapt install path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ See [examples/](https://github.com/hinzundcode/adaptjs/tree/master/examples) for
 
 ## API
 
-```
+```javascript
+new EngineBuilder([adaptInstallationPath]): EngineBuilder
 EngineBuilder.entity(name, arrayOfValues): Entity
 EngineBuilder.regexEntity(pattern): RegexEntity
 EngineBuilder.intent(name): Intent
@@ -62,3 +63,5 @@ Engine.query(input): Promise
 ## How it works
 
 The EngineBuilder on the JavaScript side creates a definition of all entities and intents and passes it to a python child process as JSON. The python child process keeps running in the background and receives new input over stdin. You have to stop the child process manually using `engine.stop()`.
+
+If you have installed Adapt in a specific location (not your current-working-directory), then you can pass that path as the first argument of the EngineBuilder. This path should be absolute, because otherwise it will be relative out of node_modules/ which _will_ lead to problems later on.

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -4,83 +4,84 @@ const spawn = require("child_process").spawn;
 const JSONStream = require("json-stream");
 
 class Engine {
-	constructor(schema) {
+	constructor(schema, adaptInstallationPath) {
 		this.schema = schema;
+    this.adaptInstallationPath = adaptInstallationPath;
 		this.worker = null;
 		this.stream = JSONStream();
 		this.queue = [];
 		this.currentJob = null;
-		
+
 		this.stream.on("data", (result) => {
 			if (!this.currentJob) return;
-			
+
 			this.currentJob.resolve(result.intents);
 			this.currentJob = null;
 			this.process();
 		});
 	}
-	
+
 	start() {
 		if (this.worker) return;
-		this.worker = spawn("python", [__dirname+"/worker.py", JSON.stringify(this.schema)]);
+		this.worker = spawn("python", [__dirname+"/worker.py", JSON.stringify(this.schema), this.adaptInstallationPath]);
 		debug("worker spawned");
-		
+
 		this.worker.on("error", err => {
 			debug("worker error");
 			debug(err);
-			
+
 			this.stop(err);
 		});
 		this.worker.on("exit", (code, signal) => {
 			debug("worker exited");
 			debug(code);
 			debug(signal);
-			
+
 			this.stop(new Error("worker exited"));
 		});
-		
+
 		this.worker.stdout.pipe(this.stream);
 		//this.worker.stdout.pipe(process.stdout);
-		
+
 		if (debug.enabled)
 			this.worker.stderr.pipe(process.stderr);
 	}
-	
+
 	stop(error) {
 		if (!error)
 			error = new Error("worker stop");
-		
+
 		if (this.worker)
 			this.worker.kill();
-		
+
 		this.worker = null;
-		
+
 		if (this.currentJob)
 			this.currentJob.reject(error);
-		
+
 		for (let job of this.queue)
 			job.reject(error);
-		
+
 		this.currentJob = null;
 		this.queue = [];
 	}
-	
+
 	isRunning() {
 		return this.worker != null;
 	}
-	
+
 	process() {
 		if (this.currentJob) return;
-		
+
 		let job = this.queue.shift();
 		if (!job) return;
 		this.currentJob = job;
-		
+
 		this.start();
 		let request = { input: job.input };
 		this.worker.stdin.write(JSON.stringify(request)+"\n");
 	}
-	
+
 	query(input) {
 		return new Promise((resolve, reject) => {
 			this.queue.push({

--- a/src/EngineBuilder.js
+++ b/src/EngineBuilder.js
@@ -5,34 +5,35 @@ const Intent = require("./Intent");
 const Engine = require("./Engine");
 
 class EngineBuilder {
-	constructor() {
+	constructor(adaptInstallationPath) {
 		this.entities = [];
 		this.intents = [];
+    this.adaptInstallationPath = adaptInstallationPath;
 	}
-	
+
 	entity(name, values) {
 		let entity = new Entity(name, values);
 		this.entities.push(entity);
 		return entity;
 	}
-	
+
 	regexEntity(pattern) {
 		let entity = new RegexEntity(pattern);
 		this.entities.push(entity);
 		return entity;
 	}
-	
+
 	intent(name) {
 		let intent = new Intent(name);
 		this.intents.push(intent);
 		return intent;
 	}
-	
+
 	build() {
 		return new Engine({
 			entities: this.entities.map(entity => entity.encode()),
-			intents: this.intents.map(intent => intent.encode()),
-		});
+			intents: this.intents.map(intent => intent.encode())
+		}, this.adaptInstallationPath);
 	}
 }
 

--- a/src/worker.py
+++ b/src/worker.py
@@ -1,5 +1,11 @@
 import json
 import sys
+
+# If there's a second argument given, use that to insert an import path
+# This enables users to use their own Adapt installation directories.
+if len(sys.argv) > 2:
+    sys.path.insert(0, sys.argv[2])
+
 from adapt.intent import IntentBuilder
 from adapt.engine import IntentDeterminationEngine
 


### PR DESCRIPTION
For some projects, Adapt may be installed in a virtualenv in a different directory. This PR adds an argument to the EngineBuilder, enabling users to specify that path.

I added new docs texts for the new feature and also fixed a little styling error in the README.